### PR TITLE
feat(AutoResponse): add `discordJSVersions` property

### DIFF
--- a/autoresponses/autoresponses.toml
+++ b/autoresponses/autoresponses.toml
@@ -3,6 +3,7 @@ keyphrases = ["istextbased is not a function"]
 content = """
 Use `v14.8.0` or newer of discord.js: `npm i discord.js@latest` *(more: <#769862166131245066>)*
 """
+discordJSVersions = ["v14"]
 mention = true
 reply = true
 
@@ -11,5 +12,16 @@ keyphrases = ["istext is not a function"]
 content = """
 Use `v13.14.0` or newer of discord.js: `npm i discord.js@v13-lts` *(more: <#769862166131245066>)*
 """
+discordJSVersions = ["v13"]
+mention = true
+reply = true
+
+[guild-members-me]
+keyphrases = ["guild.me", "<guild>.me"]
+content = """
+`<Guild>.me` is not a thing in v14. Use `<Guild>.members.me` instead.
+• [Update guide](https://discordjs.guide/additional-info/changes-in-v14.html) (use `CTRL` + `F` to search for the old method or property)
+"""
+discordJSVersions = ["v14"]
 mention = true
 reply = true

--- a/src/events/messageCreate.ts
+++ b/src/events/messageCreate.ts
@@ -1,9 +1,16 @@
 import { logger } from "@yuudachi/framework";
 import type { Event } from "@yuudachi/framework/types";
-import { Events, Client } from "discord.js";
+import { Events, Client, ChannelType } from "discord.js";
 import { container, injectable } from "tsyringe";
 import { kAutoresponses } from "../tokens.js";
 import type { AutoResponse } from "../util/autoresponses.js";
+import {
+	DiscordJSVersion,
+	V13_QUESTIONS_FORUM_TAGS,
+	V13_SUPPORT_CHANNEL,
+	V14_QUESTIONS_FORUM_TAGS,
+	V14_SUPPORT_CHANNEL,
+} from "../util/constants.js";
 
 @injectable()
 export default class implements Event {
@@ -25,17 +32,37 @@ export default class implements Event {
 
 			try {
 				for (const response of responses) {
-					if (response.keyphrases.some((phrase) => phrase.length && message.content.toLowerCase().includes(phrase))) {
-						const payload = {
-							content: response.content,
-							allowedMentions: response.mention ? { repliedUser: true } : { parse: [] },
-						};
+					const supportChannels: string[] = [];
+					const questionsForumTags: string[] = [];
 
-						if (response.reply) {
-							await message.reply(payload);
-						} else {
-							await message.channel.send(payload);
-						}
+					if (response.discordJSVersions.includes(DiscordJSVersion.V13)) {
+						supportChannels.push(V13_SUPPORT_CHANNEL);
+						questionsForumTags.push(...V13_QUESTIONS_FORUM_TAGS);
+					}
+
+					if (response.discordJSVersions.includes(DiscordJSVersion.V14)) {
+						supportChannels.push(V14_SUPPORT_CHANNEL);
+						questionsForumTags.push(...V14_QUESTIONS_FORUM_TAGS);
+					}
+
+					if (
+						(!supportChannels.includes(message.channel.id) &&
+							(message.channel.type !== ChannelType.PublicThread ||
+								!message.channel.appliedTags.some((tag) => tag.length && questionsForumTags.includes(tag)))) ||
+						!response.keyphrases.some((phrase) => phrase.length && message.content.toLowerCase().includes(phrase))
+					) {
+						continue;
+					}
+
+					const payload = {
+						content: response.content,
+						allowedMentions: response.mention ? { repliedUser: true } : { parse: [] },
+					};
+
+					if (response.reply) {
+						await message.reply(payload);
+					} else {
+						await message.channel.send(payload);
 					}
 				}
 			} catch (error_) {

--- a/src/util/autoresponses.ts
+++ b/src/util/autoresponses.ts
@@ -1,8 +1,10 @@
 import { container } from "@yuudachi/framework";
 import { kAutoresponses } from "../tokens.js";
+import type { DiscordJSVersion } from "./constants.js";
 
 export type AutoResponse = {
 	content: string;
+	discordJSVersions: DiscordJSVersion[];
 	keyphrases: string[];
 	mention: boolean;
 	reply: boolean;

--- a/src/util/constants.ts
+++ b/src/util/constants.ts
@@ -21,5 +21,15 @@ export const TAB = "\u200B \u200B \u200B" as const;
 export const EMOJI_NEWBIE = "<:newbie:962332319623049226>" as const;
 export const ASSISTCHANNELS = ["986520997006032896", "998942774994927646"];
 
+export const V14_SUPPORT_CHANNEL = "824411059443204127" as const;
+export const V13_SUPPORT_CHANNEL = "874431116533178459" as const;
+export const V14_QUESTIONS_FORUM_TAGS = ["1104357298865975336", "1102636409199792230"];
+export const V13_QUESTIONS_FORUM_TAGS = ["1104357856603557930", "1093890587599573043"];
+
+export enum DiscordJSVersion {
+	V13 = "v13",
+	V14 = "v14",
+}
+
 export const URL_REGEX =
 	/(?<url>https?:\/\/(?:www\.|(?!www))[\dA-Za-z][\dA-Za-z-]+[\dA-Za-z]\.\S{2,}|www\.[\dA-Za-z][\dA-Za-z-]+[\dA-Za-z]\.\S{2,}|https?:\/\/(?:www\.|(?!www))[\dA-Za-z]+\.\S{2,}|www\.[\dA-Za-z]+\.\S{2,})/g;


### PR DESCRIPTION
This PR adds `AutoResponse#discordJSVersions` to send responses based on the version
